### PR TITLE
wasm-cli: just use built-in readline history, cleanly handle engine shutdown

### DIFF
--- a/build.py
+++ b/build.py
@@ -119,7 +119,7 @@ CXX_FLAGS = {all_cxx_flags} -Isrc -pthread -msimd128 -mavx -flto -fno-exceptions
 LD_FLAGS = {ld_flags} \\
 	--pre-js=../../src/initModule.js -sEXIT_RUNTIME -sEXPORT_ES6 -sEXPORT_NAME={mod_name(name)} \\
 	-sEXPORTED_FUNCTIONS='[_malloc,_main]' -sEXPORTED_RUNTIME_METHODS='[stringToUTF8,UTF8ToString,HEAPU8]' \\
-	-sINCOMING_MODULE_JS_API='[locateFile,print,printErr,wasmMemory,buffer,instantiateWasm,mainScriptUrlOrBlob]' \\
+	-sINCOMING_MODULE_JS_API='[locateFile,print,printErr,wasmMemory,buffer,instantiateWasm,mainScriptUrlOrBlob,onExit]' \\
 	-sINITIAL_MEMORY=64MB -sALLOW_MEMORY_GROWTH -sSTACK_SIZE=3MB -sSTRICT -sPROXY_TO_PTHREAD \\
 	-sALLOW_BLOCKING_ON_MAIN_THREAD=0 -Wno-pthreads-mem-growth
 
@@ -276,14 +276,12 @@ def bench_run(name: TargetName) -> str | None:
             match = signature_re.search(line)
             if match:
                 signature = match.group(1)
-                break
+        if proc.wait() != 0:
+            signature = None  # Fail on unclean exit
     finally:
         watchdog.cancel()
-        proc.terminate()
-        try:
-            proc.wait(timeout=10)
-        except subprocess.TimeoutExpired:
-            proc.kill()
+        proc.kill()
+        proc.wait()
     return signature
 
 

--- a/tools/wasm-cli.ts
+++ b/tools/wasm-cli.ts
@@ -32,10 +32,18 @@ async function ensureNnue(filepath: string): Promise<Buffer> {
 }
 
 const createStockfish = (await import(`../${process.argv[2] ?? 'sf_18.js'}`)) as {
-  default: () => Promise<StockfishWeb>;
+  default: (init?: { onExit?: (code: number) => void }) => Promise<StockfishWeb>;
 };
 
-const sf = await createStockfish.default();
+const sf = await createStockfish.default({
+  onExit: (code: number) => {
+    process.exitCode = code;
+    rl.off('close', quit);
+    rl.close();
+  },
+});
+
+const quit = () => sf.uci('quit');
 
 for (let index = 0; ; index++) {
   const nnueFilename = sf.getRecommendedNnue(index);
@@ -52,10 +60,11 @@ const rl = readline.createInterface({
 
 rl.on('SIGINT', process.exit);
 
+rl.on('close', quit);
+
 rl.on('line', async line => {
   if (line.startsWith('load ')) sf.setNnueBuffer(await ensureNnue(line.slice(5)), 0);
   else if (line.startsWith('big ')) sf.setNnueBuffer(await ensureNnue(line.slice(4)), 0);
   else if (line.startsWith('small ')) sf.setNnueBuffer(await ensureNnue(line.slice(6)), 1);
-  else if (line === 'exit' || line === 'quit') process.exit();
   else sf.uci(line);
 });

--- a/tools/wasm-cli.ts
+++ b/tools/wasm-cli.ts
@@ -34,8 +34,6 @@ async function ensureNnue(filepath: string): Promise<Buffer> {
 const createStockfish = (await import(`../${process.argv[2] ?? 'sf_18.js'}`)) as {
   default: () => Promise<StockfishWeb>;
 };
-let history: string[] = [],
-  index = 0;
 
 const sf = await createStockfish.default();
 
@@ -55,23 +53,9 @@ const rl = readline.createInterface({
 rl.on('SIGINT', process.exit);
 
 rl.on('line', async line => {
-  history.push(line);
-  index = history.length;
   if (line.startsWith('load ')) sf.setNnueBuffer(await ensureNnue(line.slice(5)), 0);
   else if (line.startsWith('big ')) sf.setNnueBuffer(await ensureNnue(line.slice(4)), 0);
   else if (line.startsWith('small ')) sf.setNnueBuffer(await ensureNnue(line.slice(6)), 1);
   else if (line === 'exit' || line === 'quit') process.exit();
   else sf.uci(line);
-});
-
-process.stdin.on('keypress', (_, key) => {
-  if (key.name === 'up') {
-    if (index < 1) return;
-    rl.write(null, { ctrl: true, name: 'u' });
-    rl.write(history[--index]);
-  } else if (key.name === 'down') {
-    if (index > history.length - 2) return;
-    rl.write(null, { ctrl: true, name: 'u' });
-    rl.write(history[++index]);
-  }
 });


### PR DESCRIPTION
Shutdown handling as preparation for PGO, where `___llvm_profile_write_file` is called from exit handlers.