### PR TITLE
implement --pgo

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -71,7 +71,7 @@ jobs:
           git config --global user.email "github-actions@github.com"
 
       - name: Build and verify stockfishes
-        run: uv run build.py dist --verify-bench
+        run: uv run build.py dist --pgo --verify-bench
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v7

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ Check out https://github.com/nmrugg/stockfish.js for a simpler browser Stockfish
 ## Building
 
 ```
-# Example: Clean and make all targets
-./build.py clean all
+# Example: Clean and make all targets with pgo and final bench signature verification
+./build.py clean all --pgo --verify-bench
 ```
 
 Use `--cxx-flags` to override the default emcc flags (`-O3 -DNDEBUG --closure=1`).

--- a/build.py
+++ b/build.py
@@ -28,9 +28,9 @@ TargetName = NewType("TargetName", str)
 Tag = Literal["all", "legacy", "dist"]
 
 default_cxx_flags = [
-  "-O3",
-  "-DNDEBUG",
-  "--closure=1",
+    "-O3",
+    "-DNDEBUG",
+    "--closure=1",
 ]
 
 default_ld_flags = [
@@ -129,6 +129,8 @@ OBJS = $(addprefix src/, $(SRCS:.cpp=.o)) src/glue.o
 $(EXE).js: $(OBJS)
 	$(CXX) $(CXX_FLAGS) $(LD_FLAGS) $(OBJS) -o $(EXE).js
 
+$(OBJS): Makefile.tmp
+
 %.o: %.cpp
 	$(CXX) $(CXX_FLAGS) -c $< -o $@
 
@@ -158,6 +160,11 @@ def main() -> None:
         "--ld-flags",
         help="em++ linker flags. default: '%(default)s'",
         default=" ".join(default_ld_flags),
+    )
+    parser.add_argument(
+        "--pgo",
+        action="store_true",
+        help="profile guided optimization: build instrumented, collect profile by running bench, rebuild using the profile",
     )
     parser.add_argument(
         "--emcc-version", action="store_true", help="print required emscripten version and exit"
@@ -196,12 +203,12 @@ def main() -> None:
     for name in selected_targets:
         print("")
         print(f"# {name}")
-        build_target(name, args.cxx_flags, args.ld_flags)
+        build_target(name, cxx_flags=args.cxx_flags, ld_flags=args.ld_flags, pgo=args.pgo)
         if args.verify_bench:
             verify_bench(name)
 
 
-def build_target(name: TargetName, cxx_flags: str, ld_flags: str) -> None:
+def build_target(name: TargetName, *, cxx_flags: str, ld_flags: str, pgo: bool) -> None:
     fetch_sources(name)
 
     target_dir = fishes_dir / name
@@ -212,8 +219,46 @@ def build_target(name: TargetName, cxx_flags: str, ld_flags: str) -> None:
         if f not in ignore_sources
     ]
 
-    with open(target_dir / "Makefile.tmp", "w") as f:
-        f.write(makefile(name, sources, cxx_flags, ld_flags))
+    if pgo:
+        cxx_flags = f"{cxx_flags} -fprofile-instr-use={collect_pgo_profile(name, sources, cxx_flags=cxx_flags, ld_flags=ld_flags)}"
+
+    run_make(name, sources, cxx_flags=cxx_flags, ld_flags=ld_flags)
+
+
+def collect_pgo_profile(name: TargetName, sources: list[str], *, cxx_flags: str, ld_flags: str) -> Path:
+    target_dir = fishes_dir / name
+    profile_raw = target_dir / "pgo.profraw"
+    profile_data = target_dir / "pgo.profdata"
+    profile_raw.unlink(missing_ok=True)
+
+    run_make(
+        name,
+        sources,
+        cxx_flags=f"{cxx_flags} -fprofile-instr-generate={profile_raw} --closure=0",
+        ld_flags=f"{ld_flags} -sNODERAWFS",
+    )
+
+    print(f"running instrumented bench to collect pgo profile for {name}")
+    if bench_run(name) is None:
+        print(f"instrumented bench run failed for {name}")
+        sys.exit(1)
+    if not profile_raw.exists() or profile_raw.stat().st_size == 0:
+        print(f"instrumented bench run failed to write {profile_raw}")
+        sys.exit(1)
+
+    llvm_root = Path(subprocess.check_output(["em-config", "LLVM_ROOT"], text=True).strip())
+    llvm_profdata = llvm_root / "llvm-profdata"
+    subprocess.check_call([llvm_profdata, "merge", f"-output={profile_data}", profile_raw])
+    return profile_data
+
+
+def run_make(name: TargetName, sources: list[str], *, cxx_flags: str, ld_flags: str) -> None:
+    target_dir = fishes_dir / name
+    makefile_path = target_dir / "Makefile.tmp"
+
+    contents = makefile(name, sources, cxx_flags, ld_flags)
+    if not makefile_path.exists() or makefile_path.read_text() != contents:
+        makefile_path.write_text(contents)
 
     subprocess.check_call(["make", "-f", "Makefile.tmp", "-j"], cwd=target_dir)
 
@@ -312,6 +357,8 @@ def clean() -> None:
     clean_list = [
         *fishes_dir.glob("**/*.o"),
         *fishes_dir.glob("*/Makefile.tmp"),
+        *fishes_dir.glob("*/pgo.profraw"),
+        *fishes_dir.glob("*/pgo.profdata"),
         *[script_dir / f"{name}.{ext}" for name in targets.keys() for ext in ["js", "worker.js", "wasm", "js.map", "worker.js.map"]],
     ]
 


### PR DESCRIPTION
```
$ emcc --version
emcc (Emscripten gcc/clang-like replacement + linker emulating GNU ld) 6.0.0
[...]
```

Speedtest +6% for `sf_dev_relaxed-simd`:

```diff
 Version                    : Stockfish dev-20260711-nogit
 Compiled by                : clang++ 23.0.0 on unknown system
 Compilation architecture   : (undefined architecture)
 Compilation settings       : 32bit SSE41 SSSE3 SSE2 POPCNT
 Compiler __VERSION__ macro : Clang 23.0.0git (https:/github.com/llvm/llvm-project c6c2ad52586c28e74a724570985a48dc0022d250)
 Large pages                : no
 User invocation            : speedtest
 Filled invocation          : speedtest 32 4096 150
 Available processors       : 0-31
 Thread count               : 32
 Thread binding             : none
 TT size [MiB]              : 4096
 Hash max, avg [per mille]  :
-    single search          : 1000, 920
+    single search          : 1000, 925
     single game            : 1000, 1000
-Total nodes searched       : 2755263003
-Total search time [s]      : 149.986
-Nodes/second               : 18370134
+Total nodes searched       : 2915662581
+Total search time [s]      : 149.971
+Nodes/second               : 19441509
```

Speedtest +4% for `sf_18_smallnet`:

```diff
 Version                    : Stockfish 18
 Compiled by                : clang++ 23.0.0 on unknown system
 Compilation architecture   : (undefined architecture)
 Compilation settings       : 32bit SSE41 SSSE3 SSE2 POPCNT
 Compiler __VERSION__ macro : Clang 23.0.0git (https:/github.com/llvm/llvm-project c6c2ad52586c28e74a724570985a48dc0022d250)
 Large pages                : no
 User invocation            : speedtest
 Filled invocation          : speedtest 32 4096 150
 Available processors       : 0-31
 Thread count               : 32
 Thread binding             : none
 TT size [MiB]              : 4096
 Hash max, avg [per mille]  :
     single search          : 1000, 949
     single game            : 1000, 1000
-Total nodes searched       : 4651706982
-Total search time [s]      : 149.927
-Nodes/second               : 31026479
+Total nodes searched       : 4820883802
+Total search time [s]      : 149.923
+Nodes/second               : 32155731
```